### PR TITLE
Update syntax definition for sbnf

### DIFF
--- a/sbnf/sbnf.sbnf
+++ b/sbnf/sbnf.sbnf
@@ -2,7 +2,7 @@ extensions: sbnf
 
 prototype = ( ~comment )* ;
 
-comment = '(#+).*\n?'{comment.line, 1: punctuation.definition.comment} ;
+comment{comment.line.number-sign} = '#+'{punctuation.definition.comment} ~'$\n?';
 
 main = ( header # comments work too
        | rule
@@ -15,22 +15,31 @@ header = '[[:alnum:]_\-\.]+'{entity.name.tag}
 
 rule = '[[:alnum:]_\-\.]+'{entity.name.function}
        arguments?
-       `=`{keyword.operator}
+       `=`{keyword.operator.assignment}
        pattern
-       `;`{keyword.operator}
+       `;`{punctuation.terminator.rule}
      ;
 
 pattern = pattern-element (`|`{keyword.operator}? pattern)? ;
 
-pattern-element = '~|!'? pattern-item '\*|\?'? ;
+pattern-element = '~|!'{keyword.operator}?
+                  pattern-item
+                  '\*|\?'{keyword.control}?
+                ;
 
 pattern-item = literal arguments?
              | regex arguments?
-             | `(` pattern `)`
+             | group
              | '[[:alnum:]_\-\.]+'{variable.function}
              ;
 
-literal{string.quoted, include-prototype: false} = '`' ~'`' ;
-regex{string.quoted, include-prototype: false} = `'` (~`\'`)* ~`'` ;
+group{meta.group} = `(`{punctuation.section.group.begin} pattern `)`{punctuation.section.group.end};
+
+literal{string.quoted, include-prototype: false} = '`'{punctuation.definition.string.begin} ~'`'{punctuation.definition.string.begin} ;
+
+regex{string.quoted, include-prototype: false} = `'`{punctuation.definition.string.begin}
+                                                 ( ~`\'`{constant.character.escape} )*
+                                                 ~`'`{punctuation.definition.string.end}
+                                               ;
 
 arguments = '{[^}]*}' ;


### PR DESCRIPTION
Apply some meta, punctuation and keyword scopes, following the scope naming conventions.

Also split comment match into a push-pop context.

I used the example file as a test to get somewhat used to the syntax and to experiment with it a bit. 

I'm not overly happy about the highly indented lines, even though I do believe they help with readibility compared over hanging indents. The semicolon on a new line helps with reducing merge conflicts or generally unnecessary changes to the last line of a rule, but it does feel a little lost at times. The only idea for improvement I have would be not having a semicolon at all and instead make whitespace significant for rule definition, but sbnf itself can't even handle this yet and it makes parsing arguably more complicated.