### PR TITLE
Consistent indent style (K&R/OTBS-like)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ main : ( variable-declaration | function-definition )* ;
 
 IDENTIFIER = '\b[A-Za-z_]+\b'
 
-function-definition{meta.function}
-: type
+function-definition{meta.function} :
+  type
   IDENTIFIER{entity.name.function}
   `(`
   `)`
@@ -75,22 +75,22 @@ function-definition{meta.function}
 
 block{meta.block} : '{' statement* '}' ;
 
-statement : variable-declaration
-          | value ';'
-          | block
-          ;
+statement :
+  variable-declaration
+  | value ';'
+  | block
+;
 
 variable-declaration : type IDENTIFIER{variable} ( '=' value )? ';' ;
 
 type : IDENTIFIER{storage.type} ;
 
-value : '[0-9]+'{constant.numeric}
-      | function-call
-      ;
+value : '[0-9]+'{constant.numeric} | function-call ;
 
-# Function calls don't have arguments :)
-function-call{meta.function-call}
-: IDENTIFIER{variable.function meta.path} `(` `)` ;
+# Function calls don't have arguments 🙂
+function-call{meta.function-call} :
+  IDENTIFIER{variable.function meta.path} `(` `)`
+;
 ```
 
 The above grammar compiles to the following:
@@ -422,11 +422,11 @@ done inside any terminal or inside options.
 Examples:
 
 ```sbnf
-main
-: a['a'] # instantiates rule 1
-| a[a]   # instantiates rule 2
-| a['b'] # instantiates rule 3
-| b['b'] # error: Ambiguous instantiation
+main :
+  a['a'] # instantiates rule 1
+  | a[a]   # instantiates rule 2
+  | a['b'] # instantiates rule 3
+  | b['b'] # error: Ambiguous instantiation
 ;
 
 # Rule 1.
@@ -480,8 +480,8 @@ Examples:
 ```sbnf
 # This is a basic implementation of the html script tag embedding the javascript
 # syntax.
-script
-: '<script>'{tag.begin.script}
+script :
+  '<script>'{tag.begin.script}
   %embed['</script>']{scope:source.js, embedded.js, 0: tag.end.script}
 ;
 ```
@@ -505,15 +505,15 @@ script:
 # This is a basic implementation of a regex string. It has a prototype rule that
 # extends the regex syntax with an escape sequence for the string.
 
-regex-prototype{include-prototype: false}
-: ( ~`\'`{constant.character.escape} )*
+regex-prototype{include-prototype: false} :
+  ( ~`\'`{constant.character.escape} )*
   # A lookahead is required here, as otherwise we would only pop one context
   # The same is required in a sublime-syntax file
   ~'(?=\')'
 ;
 
-regex-string{string.quoted}
-: `'`{punctuation.definition.string.begin}
+regex-string{string.quoted} :
+  `'`{punctuation.definition.string.begin}
   %include[regex-prototype]{scope:source.regexp}
   `'`{punctuation.definition.string.end}
 ;

--- a/regexp/regexp.sbnf
+++ b/regexp/regexp.sbnf
@@ -2,6 +2,7 @@ SCOPE = `source.regexp`
 
 main{meta.literal.regexp} : ( ~literal )* ;
 
-literal : `.`{keyword.other.any}
-        | `)`{invalid.illegal.unmatched-brace}
-        ;
+literal :
+  `.`{keyword.other.any}
+  | `)`{invalid.illegal.unmatched-brace}
+;

--- a/sbnf/sbnf.sbnf
+++ b/sbnf/sbnf.sbnf
@@ -2,90 +2,94 @@ EXTENSIONS = 'sbnf'
 
 prototype : ( ~comment )* ;
 
-comment{comment.line.number-sign} : '#+'{punctuation.definition.comment}
-                                    ~'$\n?'
-                                  ;
+comment{comment.line.number-sign} :
+  '#+'{punctuation.definition.comment}
+  ~'$\n?'
+;
 
-main : ( variable
-       | rule
-       | parameters
-       )*
-     ;
+main : ( variable | rule | parameters )* ;
 
 IDENTIFIER = '[[:alnum:]_\-\.]+'
 
-variable : IDENTIFIER{entity.name.variable}
-           `=`{keyword.operator.assignment}
-           ( literal
-           | regex
-           | IDENTIFIER{variable.function} parameters?
-           )
-         ;
+variable :
+  IDENTIFIER{entity.name.variable}
+  `=`{keyword.operator.assignment}
+  (
+    literal
+    | regex
+    | IDENTIFIER{variable.function} parameters?
+  )
+;
 
-rule : IDENTIFIER{entity.name.function}
-       parameters?
-       options?
-       `:`{keyword.operator.assignment}
-       pattern
-       `;`{punctuation.terminator.rule}
-     ;
+rule :
+  IDENTIFIER{entity.name.function}
+  parameters?
+  options?
+  `:`{keyword.operator.assignment}
+  pattern
+  `;`{punctuation.terminator.rule}
+;
 
-pattern : pattern-element (`|`{keyword.operator}? pattern)? ;
+pattern : pattern-element ( `|`{keyword.operator}? pattern )? ;
 
-pattern-element : '~|!'{keyword.operator}?
-                  pattern-item
-                  '\*|\?'{keyword.control}?
-                ;
+pattern-element :
+  '~|!'{keyword.operator}?
+  pattern-item
+  '\*|\?'{keyword.control}?
+;
 
-pattern-item : literal options? embed-include?
-             | regex options? embed-include?
-             | group
-             | IDENTIFIER{variable.function} parameters? options?
-             ;
+pattern-item :
+  literal options? embed-include?
+  | regex options? embed-include?
+  | group
+  | IDENTIFIER{variable.function} parameters? options?
+;
 
-group{meta.group} : `(`{punctuation.section.group.begin}
-                    pattern
-                    `)`{punctuation.section.group.end}
-                  ;
+group{meta.group} :
+  `(`{punctuation.section.group.begin}
+  pattern
+  `)`{punctuation.section.group.end}
+;
 
-literal{string.quoted, include-prototype: false}
-: '`'{punctuation.definition.string.begin}
+literal{string.quoted, include-prototype: false} :
+  '`'{punctuation.definition.string.begin}
   ~'`'{punctuation.definition.string.end}
 ;
 
-regex{string.quoted, include-prototype: false}
-: `'`{punctuation.definition.string.begin}
+regex{string.quoted, include-prototype: false} :
+  `'`{punctuation.definition.string.begin}
   %include[regex-prototype]{scope:source.regexp}
   `'`{punctuation.definition.string.end}
 ;
 
-regex-prototype{include-prototype: false}
-: ( ~( `\'`{constant.character.escape}
-     | interpolation
-     )
-  )*
+regex-prototype{include-prototype: false} :
+  ( ~( `\'`{constant.character.escape} | interpolation ) )*
   ~'(?=\')'
 ;
 
-options{include-prototype: false}
-: '{'
+options{include-prototype: false} :
+  '{'
   ( ~interpolation )*
   ~'}'
 ;
 
-embed-include
-: '%'
+embed-include :
+  '%'
   'embed|include'{keyword}
   parameters
   options
 ;
 
-interpolation{include-prototype: false}
-: `#[`{punctuation.definition.placeholder.begin}
+interpolation{include-prototype: false} :
+  `#[`{punctuation.definition.placeholder.begin}
   parameter
   `]`{punctuation.definition.placeholder.end}
 ;
 
-parameters : `[` parameter ( `,` parameter )* `]` ;
+parameters :
+  `[`
+  parameter ( `,` parameter )*
+  `]`
+;
 
 parameter : literal | regex | IDENTIFIER{variable.parameter} ;

--- a/simplec/simplec.sbnf
+++ b/simplec/simplec.sbnf
@@ -8,8 +8,8 @@ main : ( variable-declaration | function-definition )* ;
 
 IDENTIFIER = '\b[A-Za-z_]+\b'
 
-function-definition{meta.function}
-: type
+function-definition{meta.function} :
+  type
   IDENTIFIER{entity.name.function}
   `(`
   `)`
@@ -18,19 +18,19 @@ function-definition{meta.function}
 
 block{meta.block} : '{' statement* '}' ;
 
-statement : variable-declaration
-          | value ';'
-          | block
-          ;
+statement :
+  variable-declaration
+  | value ';'
+  | block
+;
 
 variable-declaration : type IDENTIFIER{variable} ( '=' value )? ';' ;
 
 type : IDENTIFIER{storage.type} ;
 
-value : '[0-9]+'{constant.numeric}
-      | function-call
-      ;
+value : '[0-9]+'{constant.numeric} | function-call ;
 
-# Function calls don't have arguments :)
-function-call{meta.function-call}
-: IDENTIFIER{variable.function meta.path} `(` `)` ;
+# Function calls don't have arguments 🙂
+function-call{meta.function-call} :
+  IDENTIFIER{variable.function meta.path} `(` `)`
+;

--- a/tests/html/JavaScript.sbnf
+++ b/tests/html/JavaScript.sbnf
@@ -1,4 +1,5 @@
-main : ( ~( 'var'{keyword.definition.variable}
-          )
-       )*
-     ;
+main :
+  (
+    ~( 'var'{keyword.definition.variable} )
+  )*
+;

--- a/tests/html/html.sbnf
+++ b/tests/html/html.sbnf
@@ -1,32 +1,44 @@
 main : ( ~tags )* ;
 
-tags
-: tag['p']
-| tag['h1']
-| tag['h2']
-| tag['h3']
-| tag['h4']
-| tag['h5']
-| embed-tag['script', 'Packages/tests/html/JavaScript.sublime-syntax', 'js']
+tags :
+  tag['p']
+  | tag['h1']
+  | tag['h2']
+  | tag['h3']
+  | tag['h4']
+  | tag['h5']
+  | embed-tag['script', 'Packages/tests/html/JavaScript.sublime-syntax', 'js']
 ;
 
-tag[NAME]
-: '(<)(#[NAME])(>)'{meta.tag.#[NAME], 1: punctuation.definition.tag.begin,
-                                      2: entity.name.tag.begin.#[NAME],
-                                      3: punctuation.definition.tag.end}
+tag[NAME] :
+  '(<)(#[NAME])(>)'{
+    meta.tag.#[NAME],
+    1: punctuation.definition.tag.begin,
+    2: entity.name.tag.begin.#[NAME],
+    3: punctuation.definition.tag.end
+  }
   ( ~tags )*
-  ~'(</)(#[NAME])(>)'{meta.tag.#[NAME], 1: punctuation.definition.tag.begin,
-                                        2: entity.name.tag.end.#[NAME],
-                                        3: punctuation.definition.tag.end}
+  ~'(</)(#[NAME])(>)'{
+    meta.tag.#[NAME],
+    1: punctuation.definition.tag.begin,
+    2: entity.name.tag.end.#[NAME],
+    3: punctuation.definition.tag.end
+  }
 ;
 
-embed-tag[NAME, SYNTAX, SCOPE]
-: '(<)(#[NAME])(>)'{meta.tag.#[NAME], 1: punctuation.definition.tag.begin,
-                                      2: entity.name.tag.begin.#[NAME],
-                                      3: punctuation.definition.tag.end}
-  %embed['(</)(#[NAME])(>)']{#[SYNTAX], source.embedded.#[SCOPE].html,
-                                        0: meta.tag.#[NAME],
-                                        1: punctuation.definition.tag.begin,
-                                        2: entity.name.tag.end.#[NAME],
-                                        3: punctuation.definition.tag.end}
+embed-tag[NAME, SYNTAX, SCOPE] :
+  '(<)(#[NAME])(>)'{
+    meta.tag.#[NAME],
+    1: punctuation.definition.tag.begin,
+    2: entity.name.tag.begin.#[NAME],
+    3: punctuation.definition.tag.end
+  }
+  %embed['(</)(#[NAME])(>)']{
+    #[SYNTAX],
+    source.embedded.#[SCOPE].html,
+    0: meta.tag.#[NAME],
+    1: punctuation.definition.tag.begin,
+    2: entity.name.tag.end.#[NAME],
+    3: punctuation.definition.tag.end
+  }
 ;

--- a/tests/issue_18/issue_18.sbnf
+++ b/tests/issue_18/issue_18.sbnf
@@ -1,7 +1,7 @@
 main : (~str)*;
 
-str
-: '([rR])(")'{
+str :
+  '([rR])(")'{
     meta.string,
     1: storage.type.string,
     2: string.quoted.double punctuation.definition.string.begin
@@ -9,9 +9,10 @@ str
   str-impl
 ;
 
-str-impl{meta.string string.quoted.double}
-: ( ~`""`{constant.character.escape.double-quote} )*
-  ~( '"'{punctuation.definition.string.end}
-   | '\n'{invalid.illegal.unclosed-string}
-   )
+str-impl{meta.string string.quoted.double} :
+  ( ~`""`{constant.character.escape.double-quote} )*
+  ~(
+  '"'{punctuation.definition.string.end}
+    | '\n'{invalid.illegal.unclosed-string}
+  )
 ;

--- a/tests/issue_6/issue_6.sbnf
+++ b/tests/issue_6/issue_6.sbnf
@@ -1,23 +1,21 @@
 NAME = `Lisp SBNF`
 
-main : ( ~( comment
-          | symbol
-       )  )*
-     ;
+main : ( ~( comment | symbol )  )* ;
 
 # May not be only digits or periods
-symbol-char-must-have
-: '[^\s()\'"/,:;|\d.]|(\\.)'{1: constant.character.escape} ;
+symbol-char-must-have :
+  '[^\s()\'"/,:;|\d.]|(\\.)'{1: constant.character.escape}
+;
 
 symbol-char : '\d' | `.` | symbol-char-must-have ;
 
-symbol
-: symbol-char*
+symbol :
+  symbol-char*
   symbol-char-must-have
   symbol-char*
 ;
 
-comment{comment.line.semicolon}
-: ';+'{punctuation.definition.comment}
+comment{comment.line.semicolon} :
+  ';+'{punctuation.definition.comment}
   ~'$\n?'
 ;

--- a/tests/passive/passive.sbnf
+++ b/tests/passive/passive.sbnf
@@ -1,26 +1,25 @@
 prototype : ( ~comment )* ;
 
-comment{comment.line.number-sign}
-: '#+'{punctuation.definition.comment}
+comment{comment.line.number-sign} :
+  '#+'{punctuation.definition.comment}
   ~'$\n?'
 ;
 
-main
-: ( ~( test-simple-passive
-     | test-push-passive
-     )
+main :
+  (
+    ~( test-simple-passive | test-push-passive )
   )*
 ;
 
-test-simple-passive{simple-passive}
-: '\btest-simple-passive\b'
+test-simple-passive{simple-passive} :
+  '\btest-simple-passive\b'
   `"`{a}
   ( ~`foo`{b} )*
   ~`"`{c}
 ;
 
-test-push-passive{push-passive}
-: '\btest-push-passive\b'
+test-push-passive{push-passive} :
+  '\btest-push-passive\b'
   '\bfoo\b'{foo}*
   ~`;`{end}
 ;

--- a/tests/recursive_branch_points/recursive_branch_points.sbnf
+++ b/tests/recursive_branch_points/recursive_branch_points.sbnf
@@ -1,9 +1,8 @@
 SCOPE = `test`
 
-main
-: ( ~( recursive-a
-     | recursive-b
-     )
+main :
+  (
+    ~( recursive-a | recursive-b )
   )*
 ;
 

--- a/tests/simple_interpreter/simple_interpreter.sbnf
+++ b/tests/simple_interpreter/simple_interpreter.sbnf
@@ -1,10 +1,12 @@
 SCOPE = `test`
 
-main
-: ( ~( interpolation['a']
-     | interpolation['b']
-     | interpolation['c']
-     )
+main :
+  (
+    ~(
+      interpolation['a']
+      | interpolation['b']
+      | interpolation['c']
+    )
   )*
 ;
 


### PR DESCRIPTION
Personal quibble. I suggest the following indent style.

* An opening delimiter is on the same line as its cause, like `rule :` or `'lit'{`. If there's no cause, it takes its own line. Unless the inner code and closing delimiter are on the same line, an opening delimiter ends the line.
* A closing delimiter is always on its own line and dedented, matching the indent level of the opening expression.
* Code between delimiters is indented by 2 spaces from the parent level. Indentation is always increased or decreased by 2 spaces.

```sbnf
rule : expr ;

rule :
  expr
  expr
;

rule :
  expr
  (
    expr
    expr
    expr
  )*
  expr
;
```

Inner delimiters such as commas are placed at the end of each line. For now, a questionable exception is made for pipes.

```sbnf
rule :
  'literal'{
    opt,
    opt,
    opt
  }
;
```

Expressions between delimiters are either all placed on the same line, or each placed on its own line.

```sbnf
rule :
  expr expr expr
;

rule :
  expr
  expr
  expr
;
```